### PR TITLE
perf: move regexp compilations to package-level variables

### DIFF
--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -44,7 +44,10 @@ const (
 	DefaultPodManifestPath = "pod-manifests"
 )
 
-var InstanceMetadataServiceIP = net.ParseIP("169.254.169.254")
+var (
+	InstanceMetadataServiceIP = net.ParseIP("169.254.169.254")
+	nameserverRe              = regexp.MustCompile(`^nameserver\s+([^\s]*)`)
+)
 
 // Get returns a pointer to a completed Node configuration struct,
 // containing a merging of the local CLI configuration with settings from the server.
@@ -383,11 +386,10 @@ func isValidResolvConf(resolvConfFile string) bool {
 	}
 	defer file.Close()
 
-	nameserver := regexp.MustCompile(`^nameserver\s+([^\s]*)`)
 	scanner := bufio.NewScanner(file)
 	foundNameserver := false
 	for scanner.Scan() {
-		ipMatch := nameserver.FindStringSubmatch(scanner.Text())
+		ipMatch := nameserverRe.FindStringSubmatch(scanner.Text())
 		if len(ipMatch) == 2 {
 			if !isValidNameserver(ipMatch[1]) {
 				return false

--- a/pkg/configfilearg/parser.go
+++ b/pkg/configfilearg/parser.go
@@ -18,6 +18,11 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+var (
+	flagRe  = regexp.MustCompile(`^-+([^=]*)=`)
+	afterRe = regexp.MustCompile(`(.+):(\d+)`)
+)
+
 type Parser struct {
 	After         []string
 	ConfigFlags   []string
@@ -81,13 +86,9 @@ func (p *Parser) stripInvalidFlags(command string, args []string) ([]string, err
 		}
 	}
 
-	re, err := regexp.Compile("^-+([^=]*)=")
-	if err != nil {
-		return args, err
-	}
 	for _, arg := range args {
 		mArg := arg
-		if match := re.FindAllStringSubmatch(arg, -1); match != nil {
+		if match := flagRe.FindAllStringSubmatch(arg, -1); match != nil {
 			mArg = match[0][1]
 		}
 		if validFlags[mArg] {
@@ -192,14 +193,10 @@ func (p *Parser) findStart(args []string) ([]string, []string, bool) {
 	}
 	afterTemp := append([]string{}, p.After...)
 	afterIndex := make(map[string]int)
-	re, err := regexp.Compile(`(.+):(\d+)`)
-	if err != nil {
-		return args, nil, false
-	}
 	// After keywords ending with ":<NUM>" can set + NUM of arguments as the split point.
 	// used for matching on subcommmands
 	for i, arg := range afterTemp {
-		if match := re.FindAllStringSubmatch(arg, -1); match != nil {
+		if match := afterRe.FindAllStringSubmatch(arg, -1); match != nil {
 			afterTemp[i] = match[0][1]
 			afterIndex[match[0][1]], err = strconv.Atoi(match[0][2])
 			if err != nil {


### PR DESCRIPTION
## Summary

Move `regexp.Compile` and `regexp.MustCompile` calls from function bodies to package-level `var` declarations. This ensures patterns are compiled once at init time rather than on every function call.

### Changes

- **`pkg/configfilearg/parser.go`**: Extract `flagRe` and `afterRe` as package-level variables. Remove now-unnecessary error handling from the `regexp.Compile` calls (switched to `MustCompile`).
- **`pkg/agent/config/config.go`**: Extract `nameserverRe` as a package-level variable.

### Why

Compiling regexps inside function bodies is wasteful — the compiled pattern is identical every time, but the compilation cost is paid on every call. Package-level variables are compiled once at program startup.