### PR TITLE
perf: compile regex once at package level in configfilearg

### DIFF
--- a/pkg/configfilearg/parser.go
+++ b/pkg/configfilearg/parser.go
@@ -18,6 +18,8 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+var flagRegex = regexp.MustCompile("^-+([^=]*)=")
+
 type Parser struct {
 	After         []string
 	ConfigFlags   []string
@@ -81,13 +83,9 @@ func (p *Parser) stripInvalidFlags(command string, args []string) ([]string, err
 		}
 	}
 
-	re, err := regexp.Compile("^-+([^=]*)=")
-	if err != nil {
-		return args, err
-	}
 	for _, arg := range args {
 		mArg := arg
-		if match := re.FindAllStringSubmatch(arg, -1); match != nil {
+		if match := flagRegex.FindAllStringSubmatch(arg, -1); match != nil {
 			mArg = match[0][1]
 		}
 		if validFlags[mArg] {


### PR DESCRIPTION
## Summary

Move `regexp.Compile("^-+([^=]*)=")` from inside `stripInvalidFlags()` to a package-level `regexp.MustCompile` variable.

## Problem

The regex was being compiled on every invocation of `stripInvalidFlags()`, which is called during config file parsing. Since the pattern is static, recompiling it each time is unnecessary overhead.

## Solution

Declare a package-level variable:
```go
var flagRegex = regexp.MustCompile("^-+([^=]*)=")
```

This compiles the regex once at program startup and reuses it on every call, avoiding repeated compilation overhead.